### PR TITLE
fixing cli tests

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -27,18 +27,23 @@ func RunCLI(filename string, args []string, output io.Writer) {
 		flagSet.Usage()
 		return
 	}
-	//var store Store
-	//if db
-	//store = newDBStore
-	// else if file
-	//store = newFileStore
 	store := NewFileStore(filename)
-
+	tracker, err := store.Load()
+	if err != nil {
+		log.Fatal(err)
+	}
 	//TODO move this to runCLI or at least move after parsing
 	//this might mean making changing to AllHabits(store) instead of a method on Tracker
 	if len(args) == 0 {
-		fmt.Fprintln(output, AllHabits(store))
-		return
+		if len(tracker) > 0 {
+			fmt.Fprintln(output, AllHabits(store))
+			return
+		} else {
+			// no previous habits
+			fmt.Fprintln(output, help_intro)
+			flagSet.Usage()
+			return
+		}
 	}
 
 	if len(flagSet.Args()) == 0 && !serverMode {

--- a/cli_test.go
+++ b/cli_test.go
@@ -2,6 +2,8 @@ package habit_test
 
 import (
 	"bytes"
+	"fmt"
+	"github.com/phayes/freeport"
 	"habit"
 	"net/http"
 	"strings"
@@ -89,12 +91,17 @@ func TestOptionsButNoArgsShowsUsageHelp(t *testing.T) {
 
 func TestOptionServerStartsHTTPServer(t *testing.T) {
 	t.Parallel()
+	tmpFile := CreateTmpFile(t)
+	freePort, err := freeport.GetFreePort()
+	if err != nil {
+		t.Fatal(err)
+	}
+	address := fmt.Sprintf("%s:%d", localHostAddress, freePort)
 	args := []string{"-s", address}
 	buffer := bytes.Buffer{}
-	tmpFile := CreateTmpFile(t)
 
 	go habit.RunCLI(tmpFile.Name(), args, &buffer)
-	resp, err := http.Get("http://localhost:8080")
+	resp, err := http.Get("http://" + address)
 	if err != nil {
 		t.Error(err)
 	}

--- a/cli_test.go
+++ b/cli_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"habit"
 	"net/http"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -19,8 +18,8 @@ func TestNoArgsShowsUsageHelpOnNoHabits(t *testing.T) {
 	t.Parallel()
 	var args []string
 	buffer := bytes.Buffer{}
-	tmpFile := CreateTmpFile()
-	defer os.Remove(tmpFile.Name())
+	tmpFile := CreateTmpFile(t)
+
 	habit.RunCLI(tmpFile.Name(), args, &buffer)
 
 	want := usage
@@ -35,8 +34,8 @@ func TestNoArgsShowsAllHabitsWithExistingHabits(t *testing.T) {
 	t.Parallel()
 	var args []string
 	buffer := bytes.Buffer{}
-	tmpFile := CreateTmpFile()
-	defer os.Remove(tmpFile.Name())
+	tmpFile := CreateTmpFile(t)
+
 	writeTracker := habit.Tracker{
 		"piano": &habit.Habit{
 			Name:     "piano",
@@ -62,8 +61,7 @@ func TestMoreThanOneArgShowsUsageHelp(t *testing.T) {
 	t.Parallel()
 	args := []string{"blah", "blah"}
 	buffer := bytes.Buffer{}
-	tmpFile := CreateTmpFile()
-	defer os.Remove(tmpFile.Name())
+	tmpFile := CreateTmpFile(t)
 
 	want := usage
 	habit.RunCLI(tmpFile.Name(), args, &buffer)
@@ -78,8 +76,7 @@ func TestOptionsButNoArgsShowsUsageHelp(t *testing.T) {
 	t.Parallel()
 	args := []string{"-f", "daily"}
 	buffer := bytes.Buffer{}
-	tmpFile := CreateTmpFile()
-	defer os.Remove(tmpFile.Name())
+	tmpFile := CreateTmpFile(t)
 
 	want := "Usage"
 	habit.RunCLI(tmpFile.Name(), args, &buffer)
@@ -94,8 +91,7 @@ func TestOptionServerStartsHTTPServer(t *testing.T) {
 	t.Parallel()
 	args := []string{"-s", address}
 	buffer := bytes.Buffer{}
-	tmpFile := CreateTmpFile()
-	defer os.Remove(tmpFile.Name())
+	tmpFile := CreateTmpFile(t)
 
 	go habit.RunCLI(tmpFile.Name(), args, &buffer)
 	resp, err := http.Get("http://localhost:8080")

--- a/cli_test.go
+++ b/cli_test.go
@@ -103,6 +103,7 @@ func TestOptionServerStartsHTTPServerReturns404NoHabits(t *testing.T) {
 	buffer := bytes.Buffer{}
 
 	go habit.RunCLI(tmpFile.Name(), args, &buffer)
+	time.Sleep(2 * time.Second)
 	resp, err := http.Get("http://" + address)
 	if err != nil {
 		t.Fatal(err)

--- a/cli_test.go
+++ b/cli_test.go
@@ -27,7 +27,7 @@ func TestNoArgsShowsUsageHelpOnNoHabits(t *testing.T) {
 	got := buffer.String()
 
 	if !strings.Contains(got, want) {
-		t.Errorf("No arguments and no previous habits should print usage Message got\n:  %s", got)
+		t.Errorf("no arguments and no previous habits should print usage Message got\n:  %s", got)
 	}
 }
 
@@ -54,9 +54,10 @@ func TestNoArgsShowsAllHabitsWithExistingHabits(t *testing.T) {
 	got := buffer.String()
 	if !strings.Contains(got, want) {
 		// if habits exist in store, a summary of all habits should be displayed
-		t.Errorf("No arguments and previous habits should print a summary of all habits got\n:  %s", got)
+		t.Errorf("no arguments and previous habits should print a summary of all habits got\n:  %s", got)
 	}
 }
+
 func TestMoreThanOneArgShowsUsageHelp(t *testing.T) {
 	t.Parallel()
 	args := []string{"blah", "blah"}
@@ -69,7 +70,7 @@ func TestMoreThanOneArgShowsUsageHelp(t *testing.T) {
 	got := buffer.String()
 
 	if !strings.Contains(got, want) {
-		t.Errorf("No arguments should print usage Message got: %s", got)
+		t.Errorf("too many arguments should print usage Message got: %s", got)
 	}
 }
 
@@ -85,11 +86,11 @@ func TestOptionsButNoArgsShowsUsageHelp(t *testing.T) {
 	got := buffer.String()
 
 	if !strings.Contains(got, want) {
-		t.Errorf("No arguments should print usage Message got: %s", got)
+		t.Errorf("only options and no arguments should print usage Message got: %s", got)
 	}
 }
 
-func TestOptionServerStartsAHTTPSERVER(t *testing.T) {
+func TestOptionServerStartsHTTPServer(t *testing.T) {
 	t.Parallel()
 	args := []string{"-s", address}
 	buffer := bytes.Buffer{}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module habit
 
 go 1.17
 
-require github.com/mattn/go-sqlite3 v1.14.12
+require (
+	github.com/mattn/go-sqlite3 v1.14.12
+	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/mattn/go-sqlite3 v1.14.12 h1:TJ1bhYJPV44phC+IMu1u2K/i5RriLTPe+yc68XDJ1Z0=
 github.com/mattn/go-sqlite3 v1.14.12/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
+github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5 h1:Ii+DKncOVM8Cu1Hc+ETb5K+23HdAMvESYE3ZJ5b5cMI=
+github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=

--- a/habit.go
+++ b/habit.go
@@ -68,9 +68,12 @@ func (ht *Tracker) CreateHabit(habit *Habit) error {
 }
 func AllHabits(store Storable) string {
 	ht := NewTracker(store)
-	message := "Habits:\n"
-	for _, habit := range ht {
-		message += fmt.Sprintf(habitStatus+"\n", habit.Streak, habit.Name)
+	var message string
+	if len(ht) > 0 {
+		message = "Habits:\n"
+		for _, habit := range ht {
+			message += fmt.Sprintf(habitStatus+"\n", habit.Streak, habit.Name)
+		}
 	}
 	return message
 }

--- a/habit_test.go
+++ b/habit_test.go
@@ -138,7 +138,7 @@ func TestTracker_FetchHabitResetsStreakOnWeeklyHabit(t *testing.T) {
 	}
 }
 
-func TestAllHabitsReportsCurrentStreaks(t *testing.T) {
+func TestAllHabitsReturnsHabitStreaks(t *testing.T) {
 	t.Parallel()
 	tracker := habit.Tracker{
 		"piano": &habit.Habit{
@@ -147,7 +147,18 @@ func TestAllHabitsReportsCurrentStreaks(t *testing.T) {
 			DueDate: time.Now().Add(habit.DailyInterval),
 		},
 	}
+	store := habit.FileStore{Tracker: tracker}
 	want := "Habits:\nYou're currently on a 8-day streak for 'piano'. Stick to it!\n"
+	got := habit.AllHabits(store)
+	if want != got {
+		t.Errorf("want:\n %s \ngot:\n %s", want, got)
+	}
+}
+
+func TestAllHabitsReturnsEmptyStringOnNoHabits(t *testing.T) {
+	t.Parallel()
+	tracker := habit.Tracker{}
+	want := ""
 	store := habit.FileStore{Tracker: tracker}
 	got := habit.AllHabits(store)
 	if want != got {

--- a/habit_test.go
+++ b/habit_test.go
@@ -138,22 +138,22 @@ func TestTracker_FetchHabitResetsStreakOnWeeklyHabit(t *testing.T) {
 	}
 }
 
-//todo fix test
-//func TestAllHabitsReportsCurrentStreaks(t *testing.T) {
-//	t.Parallel()
-//	tracker := habit.Tracker{
-//		"piano": &habit.Habit{
-//			Name:    "piano",
-//			Streak:  8,
-//			DueDate: time.Now().Add(habit.DailyInterval),
-//		},
-//	}
-//	want := "Habits:\nYou're currently on a 8-day streak for 'piano'. Stick to it!\n"
-//	got := tracker.AllHabits()
-//	if want != got {
-//		t.Errorf("want:\n %s \ngot:\n %s", want, got)
-//	}
-//}
+func TestAllHabitsReportsCurrentStreaks(t *testing.T) {
+	t.Parallel()
+	tracker := habit.Tracker{
+		"piano": &habit.Habit{
+			Name:    "piano",
+			Streak:  8,
+			DueDate: time.Now().Add(habit.DailyInterval),
+		},
+	}
+	want := "Habits:\nYou're currently on a 8-day streak for 'piano'. Stick to it!\n"
+	store := habit.FileStore{Tracker: tracker}
+	got := habit.AllHabits(store)
+	if want != got {
+		t.Errorf("want:\n %s \ngot:\n %s", want, got)
+	}
+}
 
 func TestTracker_CreateHabitCreatesAWeeklyHabit(t *testing.T) {
 	t.Parallel()

--- a/server.go
+++ b/server.go
@@ -48,8 +48,13 @@ func (server *server) HabitHandler(w http.ResponseWriter, r *http.Request) {
 	//parsing querystring
 	habitName := r.FormValue("habit")
 	if r.RequestURI == "/all" || r.RequestURI == "/" {
-		fmt.Fprint(w, AllHabits(server.Store))
-		return
+		if len(*server.Tracker) > 0 {
+			fmt.Fprint(w, AllHabits(server.Store))
+			return
+		} else {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
 	} else if habitName == "" || r.URL.Path != "/" {
 		http.Error(w, "cannot parse querystring", http.StatusBadRequest)
 		return
@@ -63,6 +68,7 @@ func (server *server) HabitHandler(w http.ResponseWriter, r *http.Request) {
 		interval = WeeklyInterval
 	} else {
 		http.Error(w, "invalid interval", http.StatusBadRequest)
+		return
 	}
 
 	habit, ok := server.Tracker.FetchHabit(habitName)
@@ -75,6 +81,7 @@ func (server *server) HabitHandler(w http.ResponseWriter, r *http.Request) {
 		err := server.Tracker.CreateHabit(habit)
 		if err != nil {
 			http.Error(w, "not able to create habit", http.StatusInternalServerError)
+			return
 		}
 	}
 	fmt.Fprint(w, habit)

--- a/server_test.go
+++ b/server_test.go
@@ -9,6 +9,11 @@ import (
 	"testing"
 )
 
+const (
+	localHostAddress = "127.0.0.1"
+	notFound         = "not found"
+)
+
 func TestNewHttpServer(t *testing.T) {
 	t.Parallel()
 	tmpFile := CreateTmpFile(t)
@@ -139,5 +144,3 @@ func TestRouting(t *testing.T) {
 		res.Body.Close() //no defer at it might leak ;)
 	}
 }
-
-const localHostAddress = "127.0.0.1"

--- a/server_test.go
+++ b/server_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 const (
@@ -113,8 +114,14 @@ func TestServer_HabitHandleInterval(t *testing.T) {
 
 func TestRouting(t *testing.T) {
 	t.Parallel()
-	tmpFile := CreateTmpFile(t)
-	store := habit.NewFileStore(tmpFile.Name())
+	tracker := habit.Tracker{
+		"piano": &habit.Habit{
+			Name:    "piano",
+			Streak:  8,
+			DueDate: time.Now().Add(habit.DailyInterval),
+		},
+	}
+	store := habit.FileStore{Tracker: tracker}
 	habitServer := habit.NewServer(store, localHostAddress)
 	testServer := httptest.NewServer(habitServer.Handler())
 	defer testServer.Close()

--- a/server_test.go
+++ b/server_test.go
@@ -14,7 +14,7 @@ func TestNewHttpServer(t *testing.T) {
 	tmpFile := CreateTmpFile(t)
 
 	store := habit.NewFileStore(tmpFile.Name())
-	server := habit.NewServer(store, address)
+	server := habit.NewServer(store, localHostAddress)
 
 	if server.Tracker == nil {
 		t.Errorf("Tracker should not be nil")
@@ -30,7 +30,7 @@ func TestNewServerWithNonDefaultAddress(t *testing.T) {
 
 	got := server.Server.Addr
 	if want != got {
-		t.Errorf("want address to be %s, got %s", want, got)
+		t.Errorf("want localHostAddress to be %s, got %s", want, got)
 	}
 
 }
@@ -41,7 +41,7 @@ func TestHabitHandlerReturnsHabit(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/?habit=piano", nil)
 	tmpFile := CreateTmpFile(t)
 	store := habit.NewFileStore(tmpFile.Name())
-	server := habit.NewServer(store, address)
+	server := habit.NewServer(store, localHostAddress)
 	server.Tracker = &habit.Tracker{
 		"reading": &habit.Habit{
 			Name: "reading",
@@ -69,7 +69,7 @@ func TestHabitHandlerWithGibberishReturns400(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/?garbage", nil)
 	tmpFile := CreateTmpFile(t)
 	store := habit.NewFileStore(tmpFile.Name())
-	server := habit.NewServer(store, address)
+	server := habit.NewServer(store, localHostAddress)
 	server.HabitHandler(recorder, req)
 	res := recorder.Result()
 	defer res.Body.Close()
@@ -83,7 +83,7 @@ func TestServer_HabitHandleInterval(t *testing.T) {
 	t.Parallel()
 	tmpFile := CreateTmpFile(t)
 	store := habit.NewFileStore(tmpFile.Name())
-	server := habit.NewServer(store, address)
+	server := habit.NewServer(store, localHostAddress)
 
 	testCases := []struct {
 		name   string
@@ -110,7 +110,7 @@ func TestRouting(t *testing.T) {
 	t.Parallel()
 	tmpFile := CreateTmpFile(t)
 	store := habit.NewFileStore(tmpFile.Name())
-	habitServer := habit.NewServer(store, address)
+	habitServer := habit.NewServer(store, localHostAddress)
 	testServer := httptest.NewServer(habitServer.Handler())
 	defer testServer.Close()
 
@@ -140,4 +140,4 @@ func TestRouting(t *testing.T) {
 	}
 }
 
-const address = "127.0.0.1:8080"
+const localHostAddress = "127.0.0.1"

--- a/server_test.go
+++ b/server_test.go
@@ -5,15 +5,13 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 )
 
 func TestNewHttpServer(t *testing.T) {
 	t.Parallel()
-	tmpFile := CreateTmpFile()
-	defer os.Remove(tmpFile.Name())
+	tmpFile := CreateTmpFile(t)
 
 	store := habit.NewFileStore(tmpFile.Name())
 	server := habit.NewServer(store, address)
@@ -25,8 +23,7 @@ func TestNewHttpServer(t *testing.T) {
 
 func TestNewServerWithNonDefaultAddress(t *testing.T) {
 	t.Parallel()
-	tmpFile := CreateTmpFile()
-	defer os.Remove(tmpFile.Name())
+	tmpFile := CreateTmpFile(t)
 	want := "http://test.net:8080"
 	store := habit.NewFileStore(tmpFile.Name())
 	server := habit.NewServer(store, want)
@@ -42,8 +39,7 @@ func TestHabitHandlerReturnsHabit(t *testing.T) {
 	t.Parallel()
 	recorder := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/?habit=piano", nil)
-	tmpFile := CreateTmpFile()
-	defer os.Remove(tmpFile.Name())
+	tmpFile := CreateTmpFile(t)
 	store := habit.NewFileStore(tmpFile.Name())
 	server := habit.NewServer(store, address)
 	server.Tracker = &habit.Tracker{
@@ -71,8 +67,7 @@ func TestHabitHandlerWithGibberishReturns400(t *testing.T) {
 	t.Parallel()
 	recorder := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/?garbage", nil)
-	tmpFile := CreateTmpFile()
-	defer os.Remove(tmpFile.Name())
+	tmpFile := CreateTmpFile(t)
 	store := habit.NewFileStore(tmpFile.Name())
 	server := habit.NewServer(store, address)
 	server.HabitHandler(recorder, req)
@@ -86,8 +81,7 @@ func TestHabitHandlerWithGibberishReturns400(t *testing.T) {
 
 func TestServer_HabitHandleInterval(t *testing.T) {
 	t.Parallel()
-	tmpFile := CreateTmpFile()
-	defer os.Remove(tmpFile.Name())
+	tmpFile := CreateTmpFile(t)
 	store := habit.NewFileStore(tmpFile.Name())
 	server := habit.NewServer(store, address)
 
@@ -114,8 +108,7 @@ func TestServer_HabitHandleInterval(t *testing.T) {
 
 func TestRouting(t *testing.T) {
 	t.Parallel()
-	tmpFile := CreateTmpFile()
-	defer os.Remove(tmpFile.Name())
+	tmpFile := CreateTmpFile(t)
 	store := habit.NewFileStore(tmpFile.Name())
 	habitServer := habit.NewServer(store, address)
 	testServer := httptest.NewServer(habitServer.Handler())

--- a/store.go
+++ b/store.go
@@ -22,6 +22,7 @@ type Storable interface {
 
 type FileStore struct {
 	filename string
+	tracker  Tracker
 }
 
 func NewFileStore(filename string) FileStore {
@@ -29,24 +30,28 @@ func NewFileStore(filename string) FileStore {
 }
 
 func (s FileStore) Load() (Tracker, error) {
-	trackerFile, err := os.OpenFile(s.filename, os.O_CREATE|os.O_RDWR, 0600)
-	if err != nil {
-		return nil, err
-	}
-	defer trackerFile.Close()
-
-	fileBytes, err := ioutil.ReadAll(trackerFile)
-	if err != nil {
-		return nil, err
-	}
-	ht := Tracker{}
-	if len(fileBytes) > 0 {
-		err = json.Unmarshal(fileBytes, &ht)
+	if s.tracker == nil {
+		trackerFile, err := os.OpenFile(s.filename, os.O_CREATE|os.O_RDWR, 0600)
 		if err != nil {
 			return nil, err
 		}
+		defer trackerFile.Close()
+
+		fileBytes, err := ioutil.ReadAll(trackerFile)
+		if err != nil {
+			return nil, err
+		}
+		ht := Tracker{}
+		if len(fileBytes) > 0 {
+			err = json.Unmarshal(fileBytes, &ht)
+			if err != nil {
+				return nil, err
+			}
+		}
+		s.tracker = ht
+		return ht, nil
 	}
-	return ht, nil
+	return s.tracker, nil
 }
 
 func (s FileStore) Write(tracker *Tracker) error {

--- a/store.go
+++ b/store.go
@@ -22,7 +22,7 @@ type Storable interface {
 
 type FileStore struct {
 	filename string
-	tracker  Tracker
+	Tracker  Tracker
 }
 
 func NewFileStore(filename string) FileStore {
@@ -30,7 +30,7 @@ func NewFileStore(filename string) FileStore {
 }
 
 func (s FileStore) Load() (Tracker, error) {
-	if s.tracker == nil {
+	if s.Tracker == nil {
 		trackerFile, err := os.OpenFile(s.filename, os.O_CREATE|os.O_RDWR, 0600)
 		if err != nil {
 			return nil, err
@@ -48,10 +48,10 @@ func (s FileStore) Load() (Tracker, error) {
 				return nil, err
 			}
 		}
-		s.tracker = ht
+		s.Tracker = ht
 		return ht, nil
 	}
-	return s.tracker, nil
+	return s.Tracker, nil
 }
 
 func (s FileStore) Write(tracker *Tracker) error {

--- a/store_test.go
+++ b/store_test.go
@@ -2,7 +2,6 @@ package habit_test
 
 import (
 	"habit"
-	"log"
 	"os"
 	"testing"
 	"time"
@@ -18,8 +17,7 @@ func TestFileStoreRoundtripWriteRead(t *testing.T) {
 			DueDate:  time.Now().Add(habit.WeeklyInterval),
 		},
 	}
-	tmpFile := CreateTmpFile()
-	defer os.Remove(tmpFile.Name())
+	tmpFile := CreateTmpFile(t)
 
 	writeFileStore := habit.NewFileStore(tmpFile.Name())
 	writeFileStore.Write(&writeTracker)
@@ -77,11 +75,14 @@ func TestDBStoreRoundtripWriteRead(t *testing.T) {
 		t.Errorf("want loaded file to contain the same habit that was written")
 	}
 }
-func CreateTmpFile() *os.File {
-	tmpFile, err := os.CreateTemp("", "")
+
+// CreateTmpFile creates a temporary file with a random name in a temporary directory. This temporary directory gets
+// removed by t.Cleanup as part of the test so there no need to defer os.Remove the temp file
+func CreateTmpFile(t *testing.T) *os.File {
+	tmpDir := t.TempDir()
+	tmpFile, err := os.CreateTemp(tmpDir, "")
 	if err != nil {
-		log.Fatal("couldn't create tmp file")
+		t.Fatal("couldn't create tmp file")
 	}
-	defer os.Remove(tmpFile.Name())
 	return tmpFile
 }


### PR DESCRIPTION
This PR captures mostly testing related changes that were part of a code review by @bitfield. Here's a summary of the work:
- Fixed some tests error messages.
- Made `CreateTmpFile()` more flexible by leveraging t.TempDir.
- Used `freeport.GetFreePort()` to improve testing.
- Added 404 response for getAllHabits on no habits. This prompted me to include that behavior in  `AllHabits.
- Expanded `TestOptionServerStartsHTTPServer` to also check for response 200 and to make sure that the response body is correct. Also note that I had to add a 2 second sleep to let the server start up properly.